### PR TITLE
Fixes getters

### DIFF
--- a/lib/controllers/session_controller.dart
+++ b/lib/controllers/session_controller.dart
@@ -44,7 +44,7 @@ class SessionController extends ValueNotifier<AgoraSettings> {
     );
   }
 
-  void createEvents(AgoraEventHandlers? agoraEventHandlers) async {
+  void createEvents(AgoraEventHandlers? agoraEventHandlers) {
     value.engine?.setEventHandler(
       RtcEngineEventHandler(
         error: (code) {
@@ -309,7 +309,7 @@ class SessionController extends ValueNotifier<AgoraSettings> {
   Timer? timer;
 
   /// Function to auto hide the button class.
-  void toggleVisible({int? autoHideButtonTime}) async {
+  void toggleVisible({int? autoHideButtonTime}) {
     if (!(value.visible)) {
       value = value.copyWith(visible: !(value.visible));
       timer = Timer(Duration(seconds: autoHideButtonTime ?? 5), () {
@@ -367,7 +367,7 @@ class SessionController extends ValueNotifier<AgoraSettings> {
   }
 
   /// Function to swap [AgoraUser] in the floating layout.
-  Future<void> swapUser({required int index}) async {
+  void swapUser({required int index}) {
     final AgoraUser newUser = value.users[index];
     final AgoraUser tempAgoraUser = value.mainAgoraUser;
     value = value.copyWith(mainAgoraUser: newUser);

--- a/lib/src/agora_client.dart
+++ b/lib/src/agora_client.dart
@@ -17,7 +17,7 @@ class AgoraClient {
     return version;
   }
 
-  Future<List<int>> get users async {
+  List<int> get users {
     final List<int> version =
         _sessionController.value.users.map((e) => e.uid).toList();
     return version;

--- a/lib/src/agora_client.dart
+++ b/lib/src/agora_client.dart
@@ -12,7 +12,7 @@ import 'package:permission_handler/permission_handler.dart';
 class AgoraClient {
   static const MethodChannel _channel = MethodChannel('agora_uikit');
 
-  static Future<String> get platformVersion async {
+  static Future<String> getPlatformVersion() async {
     final String version = await _channel.invokeMethod('getPlatformVersion');
     return version;
   }


### PR DESCRIPTION
Closes #12.

Removes async and Future when not needed.
Turns `platformSession` into `getPlatformVersion()`.

## Release Notes

- AgoraClient's `users` is not async anymore.
- Turns `platformSession` into `getPlatformVersion()`.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [X] The QA checklist below has been completed

## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The client has to await for `AgoraClient.users` even thought it's synchronous.

Issue Number: #12

## What is the new behavior?
The client doesn't have to await for `AgoraClient.users` anymore.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## QA Checklist

### UIKit Update Checklist (Minor or Patch Release)

- [X] Using the latest version of Agora's Video SDK
- [X] Example apps are all functional
- [X] Core features are still working (both ways across platforms)
	- [ ] Camera + Mic muting works for local and remote users
	- [ ] Users are added and removed correctly when they join and leave the channel
	- [ ] Older versions of the library gracefully handle changes (Create issue if not)
	- [ ] Builtin buttons all work as expected
- [ ] Any newly deprecated methods are flagged as such inline and in documentation

<!-- Remove the next section if not applicable -->

### UIKit Update Checklist (Major Release)

- [ ] The above checklist is completed (except backwards compatibility)
- [ ] Thoroughly tested for crashes, across multiple platforms at the same time

#### QA Notes

I swapped out the `platformVersion` for `getPlatformVersion()`, but I have no strong feelings, it could be `platformVersion()`. Let me know what you guys think.