### PR TITLE
Refactors AgoraClient's initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Your application can still run the voice call when it is switched to the backgro
 ## Usage
 
 ```dart
+// First, instantiate the client
 final AgoraClient client = AgoraClient(
   agoraConnectionData: AgoraConnectionData(
     appId: "<--Add Your App Id Here-->",
@@ -80,6 +81,10 @@ final AgoraClient client = AgoraClient(
   ],
 );
 
+// Then initialize it
+await client.initialize();
+
+// Finally, have fun ;)
 @override
 Widget build(BuildContext context) {
   return MaterialApp(
@@ -97,7 +102,8 @@ Widget build(BuildContext context) {
 }
 
 ```
-
+> **NOTE**: You should properly handle errors and await for initialization before using it. 
+> Look the [example](example) for inspiration.
 
 ## UIKits
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,16 +11,26 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final AgoraClient client = AgoraClient(
-    agoraConnectionData: AgoraConnectionData(
-      appId: "<--Add your App Id here-->",
-      channelName: "test",
-    ),
-    enabledPermission: [
-      Permission.camera,
-      Permission.microphone,
-    ],
-  );
+  AgoraClient client;
+  Future<void> futureInitialize;
+
+  @override
+  void initState() {
+    super.initState();
+    client = AgoraClient(
+      agoraConnectionData: AgoraConnectionData(
+        appId: "9d98d609dca244b6a885e6c9b12a30ba",
+        channelName: "test",
+        tempToken:
+            '0069d98d609dca244b6a885e6c9b12a30baIADRJkUegWzfxt5AtMvEdHqGgqiT+vWfLpA9KgmDpcEZrAx+f9gAAAAAEACqPfBqFZvfYAEAAQAVm99g',
+      ),
+      enabledPermission: [
+        Permission.camera,
+        Permission.microphone,
+      ],
+    );
+    futureInitialize = client.initialize();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,15 +42,27 @@ class _MyAppState extends State<MyApp> {
           centerTitle: true,
         ),
         body: SafeArea(
-          child: Stack(
-            children: [
-              AgoraVideoViewer(
-                client: client,
-              ),
-              AgoraVideoButtons(
-                client: client,
-              ),
-            ],
+          child: FutureBuilder(
+            future: futureInitialize,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return Center(child: CircularProgressIndicator());
+              }
+              if (snapshot.hasError) {
+                return Center(child: Text('Some error occurred.'));
+              }
+              return Stack(
+                children: [
+                  AgoraVideoViewer(
+                    layoutType: Layout.floating,
+                    client: client,
+                  ),
+                  AgoraVideoButtons(
+                    client: client,
+                  ),
+                ],
+              );
+            },
           ),
         ),
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,10 +19,8 @@ class _MyAppState extends State<MyApp> {
     super.initState();
     client = AgoraClient(
       agoraConnectionData: AgoraConnectionData(
-        appId: "9d98d609dca244b6a885e6c9b12a30ba",
+        appId: "<--Add your App Id here-->",
         channelName: "test",
-        tempToken:
-            '0069d98d609dca244b6a885e6c9b12a30baIADRJkUegWzfxt5AtMvEdHqGgqiT+vWfLpA9KgmDpcEZrAx+f9gAAAAAEACqPfBqFZvfYAEAAQAVm99g',
       ),
       enabledPermission: [
         Permission.camera,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,7 +47,7 @@ class _MyAppState extends State<MyApp> {
                 return Center(child: CircularProgressIndicator());
               }
               if (snapshot.hasError) {
-                return Center(child: Text('Some error occurred.'));
+                return Center(child: Text("Coulnd't initialize AgoraClient."));
               }
               return Stack(
                 children: [

--- a/lib/src/agora_client.dart
+++ b/lib/src/agora_client.dart
@@ -11,6 +11,10 @@ import 'package:permission_handler/permission_handler.dart';
 /// [AgoraClient] is the main class in this UIKit. It is used to initialize our [RtcEngine], add the list of user permissions, define the channel properties and use extend the [RtcEngineEventHandler] class.
 class AgoraClient {
   static const MethodChannel _channel = MethodChannel('agora_uikit');
+  final AgoraConnectionData agoraConnectionData;
+  final List<Permission> enabledPermission;
+  final AgoraChannelData? agoraChannelData;
+  final AgoraEventHandlers? agoraEventHandlers;
 
   static Future<String> get platformVersion async {
     final String version = await _channel.invokeMethod('getPlatformVersion');
@@ -29,13 +33,28 @@ class AgoraClient {
     return _sessionController;
   }
 
+  bool _initialized;
+
+  /// Useful to check if [AgoraClient] is ready for further usage
+  ///
+  /// See `initialize()` to initialize it
+  bool get initialized => _initialized;
+
   AgoraClient({
-    required AgoraConnectionData agoraConnectionData,
-    required List<Permission> enabledPermission,
-    AgoraChannelData? agoraChannelData,
-    AgoraEventHandlers? agoraEventHandlers,
-  }) {
-    _initAgoraRtcEngine(
+    required this.agoraConnectionData,
+    required this.enabledPermission,
+    this.agoraChannelData,
+    this.agoraEventHandlers,
+  }) : _initialized = false;
+
+  /// Must be called before further usage.
+  ///
+  /// See `initialized` to check if it has been initialized already
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+    await _initAgoraRtcEngine(
       agoraConnectionData: agoraConnectionData,
       enabledPermission: enabledPermission,
       agoraChannelData: agoraChannelData,
@@ -66,5 +85,6 @@ class AgoraClient {
     }
 
     _sessionController.joinVideoChannel();
+    _initialized = true;
   }
 }


### PR DESCRIPTION
Closes #13.

Moves initialization of `AgoraClient` from its constructor (implicit) to a proper function (explicit).
This means that it's the user responsability to check for it, but it also gives the power to know when it's ready.

## Release Notes

- **BREAKING CHANGE:** Must call `initialize` on `AgoraClient` before further usage.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The GitHub Actions pass building and linting. Linter returns no warnings or errors.
- [X] The QA checklist below has been completed

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
The initialization is triggered by the constructor of `AgoraClient` at initialization and if it happens to failure, it can't recover from it.

Issue Number: #13

## What is the new behavior?
The initialization is triggered by a specific function by the client. If failure happens the client gets to know and can handle it. Also the same instance can be reused.

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

## QA Checklist

### UIKit Update Checklist (Minor or Patch Release)

- [X] Using the latest version of Agora's Video SDK
- [X] Example apps are all functional
- [X] Core features are still working (both ways across platforms)
	- [ ] Camera + Mic muting works for local and remote users
	- [ ] Users are added and removed correctly when they join and leave the channel
	- [ ] Older versions of the library gracefully handle changes (Create issue if not)
	- [ ] Builtin buttons all work as expected
- [ ] Any newly deprecated methods are flagged as such inline and in documentation